### PR TITLE
Fix step title

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -8,7 +8,7 @@
 # - Bitrise CLI guides: http://devcenter.bitrise.io/bitrise-cli/
 
 title: |-
-  Autify Run Test
+  Autify Test Run
 summary: |
   Run a test plan on Autify for Mobile.
 description: |


### PR DESCRIPTION
Since the step id is `autify-test-run`, we should align the word order.