### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  share:
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v3
+      - id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.BOT_APP_ID }}
+          private_key: ${{ secrets.BOT_PRIVATE_KEY }}
+      - run: git config --global user.name "${GITHUB_ACTOR}"
+      - run: git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+      - run: echo ${{ steps.generate-token.outputs.token }} | gh auth login --with-token
+      - run: gh auth setup-git
+      - run: gh repo sync autifyhq/bitrise-steplib -b master
+      - run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          brew install bitrise
+          bitrise run share-this-step
+        env:
+          BITRISE_STEP_VERSION: ${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,15 @@ jobs:
       - uses: actions/checkout@v3
       - run: make lint
 
+  audit-this-step:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          brew install bitrise
+          bitrise run audit-this-step
+
   integration-test:
     uses: ./.github/workflows/integration-test.yml
     with:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -8,7 +8,6 @@ app:
   - AUTIFY_TEST_WAIT_INTERVAL_SECOND: 0
   # If you want to share this step into a StepLib
   - BITRISE_STEP_ID: autify-test-run
-  - BITRISE_STEP_VERSION: "1.0.1"
   - BITRISE_STEP_GIT_CLONE_URL: https://github.com/autifyhq/bitrise-step-autify-test-run.git
   - MY_STEPLIB_REPO_FORK_GIT_URL: https://github.com/autifyhq/bitrise-steplib
 


### PR DESCRIPTION
To automate `birise run share-this-step`, this commit configures GitHub App credentials inside actions and use published tag so that we no more need to update `bitrise.yml` when releasing. Instead, just create a GitHub release with a proper semver tag, then open a PR manually using the new branch.