### PR TITLE
Fix to use ref_name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,4 +25,4 @@ jobs:
           brew install bitrise
           bitrise run share-this-step
         env:
-          BITRISE_STEP_VERSION: ${{ github.ref }}
+          BITRISE_STEP_VERSION: ${{ github.ref_name }}


### PR DESCRIPTION
`github.ref` isn't exactly the same as the tag name. `github.ref_name` would be the one we needed.