### PR TITLE
Allow to set device ids

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -108,12 +108,12 @@ workflows:
             test "$AUTIFY_TEST_RUN_EXIT_CODE" = "0"
 
     - path::./:
-        title: mobile test run --build-id CCC --device-ids device1,device2
+        title: mobile test run --build-id CCC --device-ids DDD
         inputs:
         - access_token: ${AUTIFY_ACCESS_TOKEN}
         - autify_test_url: https://mobile-app.autify.com/projects/AAA/test_plans/BBB
         - build_id: CCC
-        - device_ids: device1,device2
+        - device_ids: DDD
         - timeout: ""
         - autify_path: autify-with-proxy
         - autify_cli_installer_url: ${AUTIFY_CLI_INSTALLER_URL}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -108,6 +108,25 @@ workflows:
             test "$AUTIFY_TEST_RUN_EXIT_CODE" = "0"
 
     - path::./:
+        title: mobile test run --build-id CCC --device-ids device1,device2
+        inputs:
+        - access_token: ${AUTIFY_ACCESS_TOKEN}
+        - autify_test_url: https://mobile-app.autify.com/projects/AAA/test_plans/BBB
+        - build_id: CCC
+        - device_ids: device1,device2
+        - timeout: ""
+        - autify_path: autify-with-proxy
+        - autify_cli_installer_url: ${AUTIFY_CLI_INSTALLER_URL}
+    - script:
+        inputs:
+        - content: |
+            #!/bin/bash
+            set -ex
+            echo "$AUTIFY_TEST_RESULT_URL" | grep -E 'https://mobile-app.autify.com/projects/[^/]+/results/[^/]+'
+            test "$AUTIFY_BUILD_ID" = "CCC"
+            test "$AUTIFY_TEST_RUN_EXIT_CODE" = "0"
+
+    - path::./:
         title: failed
         inputs:
         - access_token: ${AUTIFY_ACCESS_TOKEN}

--- a/step.sh
+++ b/step.sh
@@ -65,6 +65,10 @@ if [ -n "${timeout:-}" ]; then
   add_args "-t=${timeout}"
 fi
 
+if [ -n "${device_ids:-}" ]; then
+  add_args "--device-ids=${device_ids}"
+fi
+
 export AUTIFY_CLI_USER_AGENT_SUFFIX="${AUTIFY_CLI_USER_AGENT_SUFFIX:=bitrise-step-autify-test-run}"
 
 # Execute a command

--- a/step.sh
+++ b/step.sh
@@ -8,7 +8,8 @@ function add_args() {
 }
 
 function exit_script() {
-  local code=$?
+  local code
+  code=$?
   envman add --key AUTIFY_TEST_RUN_EXIT_CODE --value "${code}"
 }
 trap exit_script EXIT

--- a/step.yml
+++ b/step.yml
@@ -112,6 +112,14 @@ inputs:
     opts:
       title: Autify CLI installer URL
       is_expand: true
+  - device_ids:
+    opts:
+      title: Device IDs to test on (optional)
+      summary: |-
+        Comma-separated list of device IDs to run the test on.
+        If not specified, the test will run on the default devices configured in the test plan.
+        Example: "device1,device2,device3"
+      is_expand: true
 
 outputs:
   - AUTIFY_TEST_RESULT_URL:


### PR DESCRIPTION
Users can specify device ids through the argument `--device-ids`, but it is not supported in the Bitrise step. This pull request allow users to specify it, so that we can choose device on run.